### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/publish_podspec.yml
+++ b/.github/workflows/publish_podspec.yml
@@ -1,5 +1,9 @@
 name: Publish AdyenWeChatPayInternal.podspec
 on: [workflow_dispatch]
+
+permissions:
+  contents: read
+
 jobs:
 
   publish:


### PR DESCRIPTION
## Summary

- improve workflow security, limiting its permissions to "read"
- rename workflow file "publich" -> "publish"

Ticket: VAST-295